### PR TITLE
Issue 23

### DIFF
--- a/codeclimate-shellcheck.cabal
+++ b/codeclimate-shellcheck.cabal
@@ -31,6 +31,7 @@ executable engine
     , containers >= 0.5.6.0  && <= 0.5.7.0
     , bytestring >= 0.10.4.0 && <= 0.11.0.0
     , directory  >= 1.2.1.0  && <= 1.3.0.0
+    , extra      >= 1.4.0    && <= 1.5.0
     , filepath   >= 1.3.0.0  && <= 1.4.0.0
     , Glob       >= 0.7.5    && <= 0.8.0
     , ShellCheck >= 0.4.1    && <= 0.5.0

--- a/codeclimate-shellcheck.cabal
+++ b/codeclimate-shellcheck.cabal
@@ -26,10 +26,12 @@ executable engine
     CC.Types
   build-depends:
       aeson      >= 0.9.0.1  && <= 0.10.0.0
+    , attoparsec >= 0.13.0.0 && <= 0.14.0.0
     , base       >= 4.7      && <= 5
     , containers >= 0.5.6.0  && <= 0.5.7.0
     , bytestring >= 0.10.4.0 && <= 0.11.0.0
     , directory  >= 1.2.1.0  && <= 1.3.0.0
+    , filepath   >= 1.3.0.0  && <= 1.4.0.0
     , Glob       >= 0.7.5    && <= 0.8.0
     , ShellCheck >= 0.4.1    && <= 0.5.0
     , text       >= 1.1.0.0  && <= 1.2.1.3

--- a/src/CC/Types.hs
+++ b/src/CC/Types.hs
@@ -7,6 +7,7 @@ module CC.Types where
 import           Control.Applicative
 import           Data.Aeson
 import           Data.Aeson.Types
+import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as DM
 import qualified Data.Text as T
 import           GHC.Generics
@@ -148,3 +149,8 @@ instance FromJSON Mapping where
 -- | An env represents mappings between check names, content and remediation
 -- values.
 type Env = DM.Map T.Text Mapping
+
+--------------------------------------------------------------------------------
+
+-- | Represents a Linux shebang, i.e. #!interpreter [optional-arg].
+data Shebang = Shebang BS.ByteString BS.ByteString

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -51,6 +51,7 @@ shellScripts paths = do
   allScripts <- filterM validateScript $ dotShFiles ++ otherFiles
   return $ fmap clean allScripts
   where
+    dirs :: [FilePath]; otherFiles :: [FilePath]
     (dirs, otherFiles) = partition hasTrailingPathSeparator paths
 
     clean :: String -> String

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -36,7 +36,7 @@ loadConfig :: FilePath -> IO Config
 loadConfig path = do
     fileExists <- doesFileExist path
     config <- if fileExists then decode <$> BSL.readFile path else return Nothing
-    return $! fromMaybe Config { _include_paths = ["./"] } config
+    return $! fromMaybe (Config []) config
 
 --------------------------------------------------------------------------------
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -48,11 +48,10 @@ printIssue = BSL.putStr . (<> "\0") . encode
 shellScripts :: [FilePath] -> IO [FilePath]
 shellScripts paths = do
   dotShFiles <- concat . fst <$> globDir patterns "."
-  otherFiles <- return files
   allScripts <- filterM validateScript $ dotShFiles ++ otherFiles
   return $ fmap clean allScripts
   where
-    (dirs, files) = partition hasTrailingPathSeparator paths
+    (dirs, otherFiles) = partition hasTrailingPathSeparator paths
 
     clean :: String -> String
     clean ('.' : '/' : x) = x

--- a/test/example
+++ b/test/example
@@ -1,0 +1,7 @@
+#!/bin/sh
+## Example of a broken script. Hit the Down Arrow button to ShellCheck it!
+for f in $(ls *.m3u)
+do
+  grep -qi hq.*mp3 $f \
+    && echo -e 'Playlist $f contains a HQ file in mp3 format'
+done


### PR DESCRIPTION
This PR adds better validation of `sh` files and also correctly handles the `include_files` field in `config.json`.

Note: I wasn't able to glob negations i.e. detect files that do not have an extension, so currently it doesn't auto-discover shell scripts without extensions.

/cc @mrb 

<hr/>
Closes #23 