### PR TITLE
Fix expansion of include path directories

### DIFF
--- a/src/CC/ShellCheck/ShellScript.hs
+++ b/src/CC/ShellCheck/ShellScript.hs
@@ -68,7 +68,7 @@ findShellScripts paths = do
     clean x = x
 
     patterns :: [Pattern]
-    patterns = fmap (compile . (++ "**/*.sh")) dirs
+    patterns = fmap (compile . (++ "**/*")) dirs
 
     validateScript :: FilePath -> IO Bool
     validateScript x = doesFileExist x &&^ isShellScript x

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -154,10 +154,10 @@ shellscriptSpecs = describe "Shellscript validation and retrieval" $ do
         result `shouldBe` [ "test/fixtures/example", "test/fixtures/example.sh" ]
 
     describe "when i specify a list of directories" $ do
-      it "should should only give me files that end with .sh" $ do
+      it "should give me all shell script files, regardless of extension" $ do
         let subject = [ "test/fixtures/" ]
         result <- findShellScripts subject
-        result `shouldBe` [ "test/fixtures/example.sh" ]
+        result `shouldBe` [ "test/fixtures/example", "test/fixtures/example.sh" ]
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
When expanding directories in the include paths, we should expand everything
(not just \*\*/\*.sh). The filtering step finds shell scripts by extension or
shebang. By expanding only .sh files, we miss any scripts that would be found
by shebang.

Ping @mrb