### PR TITLE
Set LANG env var

### DIFF
--- a/docker/Release.plan
+++ b/docker/Release.plan
@@ -1,6 +1,8 @@
 FROM progrium/busybox
 MAINTAINER Philip Cunningham <hello@filib.io>
 
+ENV LANG en_US.UTF-8
+
 ADD .local/libgmp.so.10 /usr/lib/libgmp.so.10
 
 RUN adduser -u 9000 -h /home/app -D app


### PR DESCRIPTION
We've seen some files come up as unparseable on codeclimate.com with shellcheck which behave fine when run locally with `shellcheck`: we hunted it down to differences in the locale, which affects string behavior. Setting this ENV var should fix the behavior.