### PR TITLE
Analyze shellcheck-compatible scripts. (bash, dash, ash, ksh)

### DIFF
--- a/src/CC/ShellCheck/ShellScript.hs
+++ b/src/CC/ShellCheck/ShellScript.hs
@@ -22,7 +22,7 @@ import           System.FilePath.Posix
 
 -- | Checks to see if file has correct extension.
 hasShellExtension :: FilePath -> Bool
-hasShellExtension path = takeExtension path == ".sh" || takeExtension path == ".bash" || takeExtension path == ".zsh"
+hasShellExtension path = takeExtension path == ".sh" || takeExtension path == ".bash" || takeExtension path == ".dash" || takeExtension path == ".ksh" || takeExtension path == ".ash"
 
 --------------------------------------------------------------------------------
 

--- a/src/CC/ShellCheck/ShellScript.hs
+++ b/src/CC/ShellCheck/ShellScript.hs
@@ -22,7 +22,7 @@ import           System.FilePath.Posix
 
 -- | Checks to see if file has correct extension.
 hasShellExtension :: FilePath -> Bool
-hasShellExtension path = takeExtension path == ".sh"
+hasShellExtension path = takeExtension path == ".sh" || takeExtension path == ".bash" || takeExtension path == ".zsh"
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Perhaps a better long-term solution would be to use [libmagic](https://hackage.haskell.org/package/magic-1.0.8).

Apologies if I got the syntax wrong, I don't have a Haskell environment set up right now.