### PR TITLE
Analyze shellcheck-compatible scripts. (bash, dash, ash, ksh) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ cabal.sandbox.config
 *.hp
 .stack-work/
 .local/
+TAGS
 
 # ruby
 .ruby-version

--- a/app/CLI.hs
+++ b/app/CLI.hs
@@ -1,5 +1,6 @@
 module CLI where
 
+import Data.Monoid
 import Options.Applicative
 
 --------------------------------------------------------------------------------

--- a/src/CC/ShellCheck/ShellScript.hs
+++ b/src/CC/ShellCheck/ShellScript.hs
@@ -22,7 +22,7 @@ import           System.FilePath.Posix
 
 -- | Checks to see if file has correct extension.
 hasShellExtension :: FilePath -> Bool
-hasShellExtension path = takeExtension path == ".sh" || takeExtension path == ".bash" || takeExtension path == ".zsh"
+hasShellExtension path = takeExtension path == ".sh" || takeExtension path == ".bash" || takeExtension path == ".dash" || takeExtension path == ".ksh" || takeExtension path == ".ash"
 
 --------------------------------------------------------------------------------
 

--- a/src/CC/ShellCheck/ShellScript.hs
+++ b/src/CC/ShellCheck/ShellScript.hs
@@ -22,7 +22,7 @@ import           System.FilePath.Posix
 
 -- | Checks to see if file has correct extension.
 hasShellExtension :: FilePath -> Bool
-hasShellExtension path = takeExtension path == ".sh"
+hasShellExtension path = takeExtension path == ".sh" || takeExtension path == ".bash" || takeExtension path == ".zsh"
 
 --------------------------------------------------------------------------------
 

--- a/src/CC/ShellCheck/ShellScript.hs
+++ b/src/CC/ShellCheck/ShellScript.hs
@@ -11,7 +11,9 @@ module CC.ShellCheck.ShellScript (
 
 import           Control.Monad.Extra
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as Char8
 import           Data.List
+import           Data.Monoid
 import           Data.Shebang (Shebang(..), Interpretter(..), Argument(..))
 import qualified Data.Shebang as Shebang
 import           System.Directory
@@ -20,9 +22,24 @@ import           System.FilePath.Posix
 
 --------------------------------------------------------------------------------
 
+-- | List of shells the engine should be able to handle.
+validShells :: [BS.ByteString]
+validShells = ["sh", "ash", "dash", "bash", "ksh"]
+
+--------------------------------------------------------------------------------
+
+-- | List of valid shell file extensions.
+validShellExtensions :: [BS.ByteString]
+validShellExtensions = ("." <>) <$> validShells
+
+--------------------------------------------------------------------------------
+
 -- | Checks to see if file has correct extension.
 hasShellExtension :: FilePath -> Bool
-hasShellExtension path = takeExtension path == ".sh" || takeExtension path == ".bash" || takeExtension path == ".dash" || takeExtension path == ".ksh" || takeExtension path == ".ash"
+hasShellExtension path = extension `elem` validShellExtensions
+  where
+    extension :: BS.ByteString
+    extension = Char8.pack $ takeExtension path
 
 --------------------------------------------------------------------------------
 
@@ -32,11 +49,8 @@ hasValidInterpretter (Shebang (Interpretter int) maybeArgument) =
   if BS.isSuffixOf "env" int
     then case maybeArgument of
       Nothing             -> False
-      Just (Argument arg) -> any (`BS.isPrefixOf` arg) shellScriptWhitelist
-    else any (`BS.isSuffixOf` int) shellScriptWhitelist
-  where
-    shellScriptWhitelist :: [BS.ByteString]
-    shellScriptWhitelist = ["sh", "ash", "dash", "bash", "ksh"]
+      Just (Argument arg) -> any (`BS.isPrefixOf` arg) validShells
+    else any (`BS.isSuffixOf` int) validShells
 
 --------------------------------------------------------------------------------
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -113,6 +113,26 @@ shellscriptSpecs = describe "Shellscript validation and retrieval" $ do
       let result = hasShellExtension subject
       result `shouldBe` True
 
+    it "should be valid if file has .ash extension" $ do
+      let subject = "example.ash"
+      let result = hasShellExtension subject
+      result `shouldBe` True
+
+    it "should be valid if file has .dash extension" $ do
+      let subject = "example.dash"
+      let result = hasShellExtension subject
+      result `shouldBe` True
+
+    it "should be valid if file has .bash extension" $ do
+      let subject = "example.bash"
+      let result = hasShellExtension subject
+      result `shouldBe` True
+
+    it "should be valid if file has .ksh extension" $ do
+      let subject = "example.ksh"
+      let result = hasShellExtension subject
+      result `shouldBe` True
+
     it "should not be valid if file has no extension" $ do
       let subject = "example"
       let result = hasShellExtension subject


### PR DESCRIPTION
Follows on from the very sensible idea @acook had in https://github.com/filib/codeclimate-shellcheck/pull/52 to check for the full range of ShellCheck compatible scripts.